### PR TITLE
Amend requirements.txt with django-cors-header pip package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, ci]
+    branches: master
   pull_request:
-    branches: [master, ci]
-
+    branches: master
 
 jobs:
   install_project:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.7.2
 astroid==3.1.0
 dill==0.3.8
 Django==5.0.2
+django-cors-headers==4.3.1
 iniconfig==2.0.0
 isort==5.13.2
 mccabe==0.7.0
@@ -13,4 +14,3 @@ pylint-django==2.5.5
 pylint-plugin-utils==0.8.2
 sqlparse==0.4.4
 tomlkit==0.12.3
-sqlparse==0.4.4


### PR DESCRIPTION
The reason why backend is failing is because the package isnt listed in requirements.txt. Now the runner can automatically install it and run tests.

We also dont need triggers on the `ci` branch anymore. I just had it for a test, but its too redundant for our cases.