### PR TITLE
Comment out frontend_build CI rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,18 @@ jobs:
         with:
           python-version: 3.12
 
-  frontend_build:
-    needs: install_project
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: client
-    steps:
-      - name: Check out project
-        uses: actions/checkout@v4
+  #frontend_build:
+  #  needs: install_project
+  #  runs-on: ubuntu-latest
+  #  defaults:
+  #    run:
+  #      working-directory: client
+  #  steps:
+  #    - name: Check out project
+  #      uses: actions/checkout@v4
 
-      - run: npm install
-      - run: npm run build
+  #    - run: npm install
+  #    - run: npm run build
 
   frontend_test:
     needs: install_project


### PR DESCRIPTION
The build rule is not necessarily needed at the moment. This change made to reduce noise until its needed.